### PR TITLE
Use Gradle Plugin syntax for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ A Gradle plugin to add Android style flavours to a Java project
 ## Usage:
 
 ```groovy
-apply plugin: 'com.lazan.javaflavours'
+plugins {
+  id "com.lazan.javaflavours" version "1.2"
+}
 javaFlavours {
     flavour 'free'
     flavour 'paid'
@@ -20,6 +22,8 @@ dependencies {
     paidRuntime     'ddd:ddd:4.0'
 }
 ```
+
+You find detailed installation instructions at https://plugins.gradle.org/plugin/com.lazan.javaflavours.
 
 ## Directories:
 


### PR DESCRIPTION
With this update, the README.md is self-contained and the example can be more easily adapted to the own project. With the previous version, more adaptions had to be made.

This is based on https://plugins.gradle.org/plugin/com.lazan.javaflavours